### PR TITLE
Use Firefox built-in All Files filter

### DIFF
--- a/content/about-openwith.js
+++ b/content/about-openwith.js
@@ -15,9 +15,7 @@ let browserWindow = Services.wm.getMostRecentWindow('navigator:browser');
 let fp = Cc['@mozilla.org/filepicker;1'].createInstance(Ci.nsIFilePicker);
 fp.init(this, document.title, Ci.nsIFilePicker.modeOpen);
 fp.appendFilters(Ci.nsIFilePicker.filterApps);
-if (Services.appinfo.OS == 'WINNT') {
-	fp.appendFilter(OpenWithCore.strings.GetStringFromName('allFiles'), '*.*');
-}
+fp.appendFilters(Ci.nsIFilePicker.filterAll);
 
 let appsDir = null;
 if (Services.dirsvc.has('ProgF')) {

--- a/locale/ar/openwith.properties
+++ b/locale/ar/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = اختر اختصار لوحة المفاتيح لـ%S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = نسخ %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = جميع الملفات
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/bg/openwith.properties
+++ b/locale/bg/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/ca/openwith.properties
+++ b/locale/ca/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/cs/openwith.properties
+++ b/locale/cs/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Vyberte klávesovou zkratku pro %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S - kopie
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Všechny soubory
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/de/openwith.properties
+++ b/locale/de/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Wählen Sie eine Tastenkombination für %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S kopie
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Alle Dateien
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Strg

--- a/locale/el/openwith.properties
+++ b/locale/el/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Επιλέξτε μια συντόμευση πληκτρο�
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S - αντίτυπο
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Όλα τα αρχεία
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/en-US/openwith.properties
+++ b/locale/en-US/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/es-ES/openwith.properties
+++ b/locale/es-ES/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Seleccione un atajo del teclado para %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = Copia %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Todos los archivos
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = CTRL

--- a/locale/fi/openwith.properties
+++ b/locale/fi/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/fr/openwith.properties
+++ b/locale/fr/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Sélectionnez un raccourci clavier pour %S :
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = copie %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Tous les fichiers
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/hu/openwith.properties
+++ b/locale/hu/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/is/openwith.properties
+++ b/locale/is/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/it/openwith.properties
+++ b/locale/it/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Scegliere una scorciatoia per %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = Copia di %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Tutti i file
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Control

--- a/locale/ja/openwith.properties
+++ b/locale/ja/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S コピー
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/nl/openwith.properties
+++ b/locale/nl/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S kopiëren
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/pl/openwith.properties
+++ b/locale/pl/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Ustaw skrót klawiszowy dla %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = Kopia %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Wszystkie pliki
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/pt-BR/openwith.properties
+++ b/locale/pt-BR/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Selecione um atalho de teclado para %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = Cópia de %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Todos os Arquivos
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/pt-PT/openwith.properties
+++ b/locale/pt-PT/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Seleccione uma tecla de atalho para %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S cópia
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Todos os Ficheiros
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/ru/openwith.properties
+++ b/locale/ru/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Выберите горячие клавиши для %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = копия %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Все файлы
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/sr/openwith.properties
+++ b/locale/sr/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S copy
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/sv-SE/openwith.properties
+++ b/locale/sv-SE/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Select a keyboard shortcut for %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S kopiera
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Samtliga filer
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/tr/openwith.properties
+++ b/locale/tr/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = %S için yeni bir klavye kısayolu girin:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S kopyala
-# This is displayed in the Windows 'open file' dialog.
-allFiles = All Files
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/uk/openwith.properties
+++ b/locale/uk/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Оберіть поєднання клавіш для %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = Копія %S
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Всі файли
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/vi/openwith.properties
+++ b/locale/vi/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = Chọn phím tắt bàn phím cho %S:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S - Bản sao
-# This is displayed in the Windows 'open file' dialog.
-allFiles = Tất cả tập tin
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/zh-CN/openwith.properties
+++ b/locale/zh-CN/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = 为 %S  分配一个菜单快捷键:
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S 副本
-# This is displayed in the Windows 'open file' dialog.
-allFiles = 所有文件
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl

--- a/locale/zh-TW/openwith.properties
+++ b/locale/zh-TW/openwith.properties
@@ -25,8 +25,6 @@ keyinfoPromptText = 選取一個鍵盤快捷鍵給 %S 使用：
 # %S is the name of the entry being cloned.
 # @example %S Google Chrome
 duplicatedBrowserNewName = %S 拷貝
-# This is displayed in the Windows 'open file' dialog.
-allFiles = 所有檔案
 
 # These are the names for keys, used for showing keyboard shortcuts.
 ctrlkey = Ctrl


### PR DESCRIPTION
This will give a "All Files" option in Open Dialog for all platforms, and no need to use a custom filter.
Not sure about Linux, but it's useful for Mac users since the 'filterApps' doesn't include shell scripts and unix executables.