### PR TITLE
Update zh-CN name

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -151,8 +151,8 @@
 		<em:localized>
 			<Description>
 				<em:locale>zh-CN</em:locale>
-				<em:name>Open With</em:name>
-				<em:description>轻轻一点，快速打开您的网页在 Internet Explorer、Chrome、Safari 和 Opera 等浏览器。</em:description>
+				<em:name>打开方式</em:name>
+				<em:description>轻轻一点，在 Internet Explorer、Chrome、Safari 和 Opera 等浏览器上快速打开您的网页。</em:description>
 			</Description>
 		</em:localized>
 		<em:localized>


### PR DESCRIPTION
Replacing zh-CN locale name as “打开方式”, modify the description, following #97.

Seen from #97, I found the follwing change:
```
versionChanged = “打开方式”已更新到版本 %S。“打开方式”是一款免费软件，但还请考虑捐助本项目。
```
This means the addon should be renamed as “打开方式” for zh-CN locale, and I got this message when I updated, but the addon name has no change in Add-on manager. This fixes that.