### PR TITLE
Fix opening sidebar/popup URL of other extensions instead of tab.url

### DIFF
--- a/webextension/background.js
+++ b/webextension/background.js
@@ -25,9 +25,9 @@ function get_target_url(info) {
 	return info.pageUrl;
 }
 
-function context_menu_clicked(info) {
+function context_menu_clicked(info, tab) {
 	let browser_id = parseInt(info.menuItemId.substring(8), 10);
-	let url = get_target_url(info);
+	let url = tab ? tab.url : get_target_url(info);
 	if ('modifiers' in info && info.modifiers.includes('Ctrl')) {
 		url = null;
 	}


### PR DESCRIPTION
[Someone reported](https://framagit.org/ariasuni/tabcenter-reborn/-/issues/74) that this extension doesn’t work from [Tab Center Reborn](https://addons.mozilla.org/firefox/addon/tabcenter-reborn/). I can reproduce with Tree Style Tab, too.

Indeed, when your extension is used from a context menu invoked from another extension, it didn’t check for `tab.url` first, and instead found the page URL, in this case the URL of the panel or popup. Now it checks for `tab.url` first, then try to find the URL like before.