### PR TITLE
Add ungoogled-chromium installation support.

### DIFF
--- a/webextension/native/open_with_linux.py
+++ b/webextension/native/open_with_linux.py
@@ -67,6 +67,7 @@ def install():
 		'chrome-unstable': os.path.join(home_path, '.config', 'google-chrome-unstable', 'NativeMessagingHosts'),
 		'chromium': os.path.join(home_path, '.config', 'chromium', 'NativeMessagingHosts'),
 		'firefox': os.path.join(home_path, '.mozilla', 'native-messaging-hosts'),
+		'ungoogled-chromium': os.path.join(home_path, '.config', 'ungoogled-chromium', 'NativeMessagingHosts'),
 	}
 	filename = 'open_with.json'
 
@@ -117,6 +118,8 @@ def find_browsers():
 		'Chrome',
 		'Chromium',
 		'chromium-browser',
+		'ungoogled-chromium',
+		'chromium-browser-privacy', # alt name for ungoogled-chromium
 		'firefox',
 		'Firefox',
 		'Google Chrome',


### PR DESCRIPTION
Previously, the native messaging host manifest file wouldn't install to ungoogled-chromium's NativeMessagingHosts directory, so to make open-with work, one had to manually copy the manifest file into this directory. With this commit, the installer now supports installing the manifest file on ungoogled-chromium. This commit also adds detection for ungoogled-chromium when looking for browsers. This commit is only aimed at Linux.