### PR TITLE
fix open_with_mac.py Thunderbird on MacOS path.

### DIFF
--- a/webextension/native/open_with_mac.py
+++ b/webextension/native/open_with_mac.py
@@ -65,7 +65,8 @@ def install():
 		'chrome': os.path.join(home_path, 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'),
 		'chromium': os.path.join(home_path, 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'),
 		'firefox': os.path.join(home_path, 'Library', 'Application Support', 'Mozilla', 'NativeMessagingHosts'),
-		'thunderbird': os.path.join(home_path, 'Library', 'Mozilla', 'NativeMessagingHosts'),
+		'thunderbird1': os.path.join(home_path, 'Library', 'Application Support', 'Thunderbird', 'NativeMessagingHosts'),
+		'thunderbird2': os.path.join(home_path, 'Library', 'Mozilla', 'NativeMessagingHosts'),
 	}
 	filename = 'open_with.json'
 

--- a/webextension/native/open_with_mac.py
+++ b/webextension/native/open_with_mac.py
@@ -76,7 +76,7 @@ def install():
 				os.mkdir(location)
 
 			browser_manifest = manifest.copy()
-			if browser in ['firefox', 'thunderbird']:
+			if browser in ['firefox', 'thunderbird1', 'thunderbird2']:
 				browser_manifest['allowed_extensions'] = ['openwith@darktrojan.net']
 			else:
 				browser_manifest['allowed_origins'] = [

--- a/webextension/native/open_with_mac.py
+++ b/webextension/native/open_with_mac.py
@@ -65,7 +65,7 @@ def install():
 		'chrome': os.path.join(home_path, 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'),
 		'chromium': os.path.join(home_path, 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'),
 		'firefox': os.path.join(home_path, 'Library', 'Application Support', 'Mozilla', 'NativeMessagingHosts'),
-		'thunderbird': os.path.join(home_path, 'Library', 'Application Support', 'Thunderbird', 'NativeMessagingHosts'),
+		'thunderbird': os.path.join(home_path, 'Library', 'Mozilla', 'NativeMessagingHosts'),
 	}
 	filename = 'open_with.json'
 


### PR DESCRIPTION
Fix for the different path for NativeMessagingHost for Thunderbird on MacOS.

I tested a fresh installation of Thunderbird 78.5.1 on MacOS (Big Sur) and it creates `~/Library/Mozilla` and uses `~/Library/Mozilla/NativeMessagingHosts`. It does not create or use `~/Library/Application Support/Thunderbird`.

See also comments in #284.

I could add the `~/Library/Application Support/Thunderbird` version to the script if you prefer to keep that version too.