### PR TITLE
Update native-host browser list

### DIFF
--- a/webextension/native/open_with_linux.py
+++ b/webextension/native/open_with_linux.py
@@ -117,6 +117,7 @@ def find_browsers():
 	apps = [
 		'Chrome',
 		'Chromium',
+		'chromium',
 		'chromium-browser',
 		'firefox',
 		'Firefox',


### PR DESCRIPTION
On Arch Linux, chromium desktop file is lower-cased (`chromium.desktop` instead of `Chromium.desktop`). see:
https://github.com/archlinux/svntogit-packages/blob/70afede9b4cb229461947458b8aaccd74c348cd2/trunk/PKGBUILD#L194-L195